### PR TITLE
fixes Toolips.jl url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 <img src="https://github.com/ChifiSource/image_dump/blob/main/laboratory/tools/chifiProxy.png" width=170></img>
 </div>
 
-A proxy server for Julia built using [toolips](https://github,com/ChifiSource/Toolips.jl) `0.3`
+A proxy server for Julia built using [toolips](https://github.com/ChifiSource/Toolips.jl) `0.3`


### PR DESCRIPTION
Hi 👋

Saw the url of the Toolips.jl in the readme is `https://github,com/ChifiSource/Toolips.jl`
this fixes the typo.

Thanks.